### PR TITLE
Skip empty headings

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -27,6 +27,10 @@ function numberHeadings(add){
     if (!eTypeString.match(/Heading \d/)) {
       continue;
     }
+    
+    if(eText.trim === ''){
+      continue;
+    }
 
     if (add == true) {
       var patt = new RegExp(/Heading (\d)/);


### PR DESCRIPTION
Skip empty headings, generated by e.g. page breaks.