### PR TITLE
Omit blank or empty headers

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -27,6 +27,9 @@ function numberHeadings(add){
     if (!eTypeString.match(/Heading \d/)) {
       continue;
     }
+    if( eText.match(/^\s*$/)){
+      continue;
+    }
 
     if (add == true) {
       var patt = new RegExp(/Heading (\d)/);


### PR DESCRIPTION
Hi,
I find sometimes I get spaces in my documents which happen to be in a header style. This patch stops those from getting enumerated.
