### PR TITLE
Prevent data loss if header begins with a number

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -32,6 +32,8 @@ function numberHeadings(add){
     if( text.match(/^\s*$/)){
       continue;
     }
+    
+    var numberingRegex = /^[0-9]+(\.[0-9]+)*\. /;
 
     if (add == true) {
       var level = new RegExp(/HEADING(\d)/).exec(type)[1];
@@ -46,12 +48,12 @@ function numberHeadings(add){
         }
       }
       Logger.log(text);
-      var newText = numbering + ' ' + text.replace(/^[0-9\.\s]+/, '');
+      var newText = numbering + ' ' + text.replace(numberingRegex. /, '');
       element.setText(newText);
       Logger.log([newText]);
     } else {
       Logger.log(text);
-      element.setText(text.replace(/^[0-9\.\s]+/, ''));
+      element.setText(text.replace(numberingRegex, ''));
     }
   }
 

--- a/code.gs
+++ b/code.gs
@@ -48,7 +48,7 @@ function numberHeadings(add){
         }
       }
       Logger.log(text);
-      var newText = numbering + ' ' + text.replace(numberingRegex. /, '');
+      var newText = numbering + ' ' + text.replace(numberingRegex, '');
       element.setText(newText);
       Logger.log([newText]);
     } else {


### PR DESCRIPTION
If a header's text begins with a number, this script will remove the number when run. For example, if a header starts with a date such as "4/5/2020", it will become "1. /5/2020" when the script is run. This commit modifies the regex that is used to extract the numbering from the header so that this does not happen.