### PR TITLE
Remove last point for subheadings

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -45,6 +45,9 @@ function numberHeadings(add){
           numbers[currentLevel] = 0;
         }
       }
+      if (!numbering.match(/^[0-9]+\.$/)) {
+        numbering = numbering.replace(/.$/, '');
+      }
       Logger.log(text);
       var newText = numbering + ' ' + text.replace(/^[0-9\.\s]+/, '');
       element.setText(newText);


### PR DESCRIPTION
If you have subheadings this script will also place a point after the last number, e.g. "1.2.1. Some Heading". This commit ensures that the last point after a subheading will be removed. Main headings are not affected.